### PR TITLE
Adding parser implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Saugvinon is a tree walking interpreter written in Rust.
 - [x] Basic Lexer
 - [x] Extended Lexer
 - [x] REPL
+- [x] AST constructor
 - [ ] Parser
-- [ ] AST constructor
 - [ ] Internal object system
 - [ ] Evaluator
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -13,9 +13,9 @@ pub enum Statement {
 pub enum Expression {
     Ident(Token),
     IntLiteral(i64),
-    PrefixOperator {
-        prefix: Token,
-        expr: Box<Expression>,
+    PrefixExpression {
+        operator: Token,
+        right: Box<Expression>,
     },
     Empty,
 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -6,7 +6,6 @@ pub enum Statement {
     LetStatement { ident: Token, expr: Expression },
     ReturnStatement(Expression),
     ExpressionStatement(Expression),
-    Empty,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -22,7 +21,6 @@ pub enum Expression {
         left: Box<Expression>,
         right: Box<Expression>,
     },
-    Empty,
 }
 
 pub type Program = BlockStatement;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -13,6 +13,10 @@ pub enum Statement {
 pub enum Expression {
     Ident(Token),
     IntLiteral(i64),
+    PrefixOperator {
+        prefix: Token,
+        expr: Box<Expression>,
+    },
     Empty,
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -17,6 +17,11 @@ pub enum Expression {
         operator: Token,
         right: Box<Expression>,
     },
+    InfixExpression {
+        operator: Token,
+        left: Box<Expression>,
+        right: Box<Expression>,
+    },
     Empty,
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,17 @@
+#![allow(dead_code)]
+use crate::lexer::Token;
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Statement {
+    LetStatement { ident: Token, expr: Expression },
+    Empty,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Expression {
+    Empty,
+}
+
+pub type Program = BlockStatement;
+
+pub type BlockStatement = Vec<Statement>;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -4,11 +4,15 @@ use crate::lexer::Token;
 #[derive(Debug, PartialEq, Clone)]
 pub enum Statement {
     LetStatement { ident: Token, expr: Expression },
+    ReturnStatement(Expression),
+    ExpressionStatement(Expression),
     Empty,
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
+    Ident(Token),
+    IntLiteral(i64),
     Empty,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
+mod ast;
 mod lexer;
+mod parser;
 mod repl;
 
 fn main() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,0 +1,107 @@
+#![allow(dead_code)]
+use crate::ast::*;
+use crate::lexer::{Lexer, Token};
+use std::iter::Peekable;
+use std::mem::discriminant;
+
+pub struct Parser<'a> {
+    lexer: Peekable<Lexer<'a>>,
+    cursor: Token,
+}
+
+impl<'a> Parser<'a> {
+    pub fn new(mut lexer: Lexer<'a>) -> Parser<'a> {
+        let tok = lexer.next().unwrap();
+        Parser {
+            lexer: lexer.peekable(),
+            cursor: tok,
+        }
+    }
+
+    pub fn parse_program(&mut self) -> Result<Program, String> {
+        let mut program: Program = Vec::new();
+        while self.cursor != Token::EOF {
+            let statement = self.parse_statement()?;
+            program.push(statement);
+            self.next_token();
+        }
+        Ok(program)
+    }
+
+    fn next_token(&mut self) {
+        self.cursor = self.lexer.next().unwrap();
+    }
+
+    fn expect_token(&mut self, expect: Token) -> Result<(), String> {
+        match self.lexer.peek() {
+            Some(tok) if discriminant(tok) == discriminant(&expect) => {
+                self.next_token();
+                Ok(())
+            }
+            _ => Err(format!(
+                "unexpected token: expected {:?} got {:?} instead",
+                expect, self.cursor
+            )),
+        }
+    }
+
+    fn parse_statement(&mut self) -> Result<Statement, String> {
+        match self.cursor {
+            Token::Let => self.parse_let_statement(),
+            _ => Err("Invalid token".to_string()),
+        }
+    }
+
+    fn parse_let_statement(&mut self) -> Result<Statement, String> {
+        self.expect_token(Token::Ident("".to_string()))?;
+        let ident = self.cursor.clone();
+        self.expect_token(Token::Assign)?;
+
+        // TODO: skipping expressions
+        while self.cursor != Token::Semicolon {
+            self.next_token();
+        }
+        Ok(Statement::LetStatement {
+            ident,
+            expr: Expression::Empty,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Lexer, Parser, Token};
+    use crate::ast::{Expression, Statement};
+
+    #[test]
+    fn test_let_statements() -> Result<(), String> {
+        let input = "let x = ;
+        let y = 10;
+        let foobar = 838383;";
+        let lexer = Lexer::new(input);
+        let mut parser = Parser::new(lexer);
+
+        let program = parser.parse_program()?;
+        println!("Program: {:?}", program);
+        let mut statements = program.iter();
+
+        let tests = [
+            Statement::LetStatement {
+                ident: Token::Ident("x".to_string()),
+                expr: Expression::Empty,
+            },
+            Statement::LetStatement {
+                ident: Token::Ident("y".to_string()),
+                expr: Expression::Empty,
+            },
+        ];
+
+        for test in &tests {
+            match statements.next() {
+                Some(tok) => assert_eq!(*test, *tok),
+                None => panic!("unexpected parser error: returned None"),
+            };
+        }
+        Ok(())
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -67,11 +67,11 @@ impl<'a> Parser<'a> {
     fn parse_return_statement(&mut self) -> Result<Statement, String> {
         self.next_token();
 
-        // TODO: skipping expressions
-        while self.cursor != Token::Semicolon {
+        let expr = self.parse_expression(Precedence::Lowest)?;
+        if let Some(Token::Semicolon) = self.lexer.peek() {
             self.next_token();
         }
-        Ok(Statement::ReturnStatement(Expression::Empty))
+        Ok(Statement::ReturnStatement(expr))
     }
 
     fn parse_expression_statement(&mut self) -> Result<Statement, String> {
@@ -93,13 +93,55 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_expression(&mut self, _precedence: Precedence) -> Result<Expression, String> {
-        match self.cursor {
+    fn parse_expression(&mut self, precedence: Precedence) -> Result<Expression, String> {
+        let mut left = match self.cursor {
             Token::Ident(_) => Ok(Expression::Ident(self.cursor.clone())),
             Token::IntLiteral(i) => Ok(Expression::IntLiteral(i)),
             Token::Bang => self.parse_prefix_expr(),
             Token::Minus => self.parse_prefix_expr(),
             _ => Err(format!("unexpected token {:?} in expression", self.cursor)),
+        }?;
+
+        while precedence < Parser::map_precedence(self.lexer.peek().unwrap()) {
+            left = match self.lexer.peek() {
+                Some(Token::Semicolon) => break,
+                Some(Token::Plus) => self.parse_infix_expr(left)?,
+                Some(Token::Minus) => self.parse_infix_expr(left)?,
+                Some(Token::Slash) => self.parse_infix_expr(left)?,
+                Some(Token::Asterisk) => self.parse_infix_expr(left)?,
+                Some(Token::Equal) => self.parse_infix_expr(left)?,
+                Some(Token::NotEqual) => self.parse_infix_expr(left)?,
+                Some(Token::LessThan) => self.parse_infix_expr(left)?,
+                Some(Token::GreaterThan) => self.parse_infix_expr(left)?,
+                _ => break,
+            };
+        }
+        Ok(left)
+    }
+
+    fn parse_infix_expr(&mut self, left: Expression) -> Result<Expression, String> {
+        self.next_token();
+        let token = self.cursor.clone();
+        let precedence = Parser::map_precedence(&self.cursor);
+        self.next_token();
+        Ok(Expression::InfixExpression {
+            left: Box::new(left),
+            operator: token,
+            right: Box::new(self.parse_expression(precedence)?),
+        })
+    }
+
+    fn map_precedence(token: &Token) -> Precedence {
+        match token {
+            Token::Equal => Precedence::Equality,
+            Token::NotEqual => Precedence::Equality,
+            Token::LessThan => Precedence::Comparison,
+            Token::GreaterThan => Precedence::Comparison,
+            Token::Plus => Precedence::Sum,
+            Token::Minus => Precedence::Sum,
+            Token::Slash => Precedence::Product,
+            Token::Asterisk => Precedence::Product,
+            _ => Precedence::Lowest,
         }
     }
 
@@ -107,15 +149,12 @@ impl<'a> Parser<'a> {
         self.expect_token(Token::Ident("".to_string()))?;
         let ident = self.cursor.clone();
         self.expect_token(Token::Assign)?;
-
-        // TODO: skipping expressions
-        while self.cursor != Token::Semicolon {
+        self.next_token();
+        let expr = self.parse_expression(Precedence::Lowest)?;
+        if let Some(Token::Semicolon) = self.lexer.peek() {
             self.next_token();
         }
-        Ok(Statement::LetStatement {
-            ident,
-            expr: Expression::Empty,
-        })
+        Ok(Statement::LetStatement { ident, expr })
     }
 }
 
@@ -126,24 +165,34 @@ mod tests {
 
     #[test]
     fn test_let_statements() -> Result<(), String> {
-        let input = "let x = ;
+        let input = "let x = -1;
         let y = 10;
-        let foobar = 838383;";
+        let foobar = 838383 + 1;";
         let lexer = Lexer::new(input);
         let mut parser = Parser::new(lexer);
 
         let program = parser.parse_program()?;
         let mut statements = program.iter();
 
-        // TODO: Update test cases with proper expressions
         let tests = [
             Statement::LetStatement {
                 ident: Token::Ident("x".to_string()),
-                expr: Expression::Empty,
+                expr: Expression::PrefixExpression {
+                    operator: Token::Minus,
+                    right: Box::new(Expression::IntLiteral(1)),
+                },
             },
             Statement::LetStatement {
                 ident: Token::Ident("y".to_string()),
-                expr: Expression::Empty,
+                expr: Expression::IntLiteral(10),
+            },
+            Statement::LetStatement {
+                ident: Token::Ident("foobar".to_string()),
+                expr: Expression::InfixExpression {
+                    left: Box::new(Expression::IntLiteral(838383)),
+                    operator: Token::Plus,
+                    right: Box::new(Expression::IntLiteral(1)),
+                },
             },
         ];
 
@@ -158,7 +207,7 @@ mod tests {
 
     #[test]
     fn test_return_statements() -> Result<(), String> {
-        let input = "return 5;
+        let input = "return -5;
         return 10;
         return 993322;";
         let lexer = Lexer::new(input);
@@ -167,10 +216,14 @@ mod tests {
         let program = parser.parse_program()?;
         let mut statements = program.iter();
 
-        // TODO: Update test cases with proper expressions
+        // Update test cases with proper expressions
         let tests = [
-            Statement::ReturnStatement(Expression::Empty),
-            Statement::ReturnStatement(Expression::Empty),
+            Statement::ReturnStatement(Expression::PrefixExpression {
+                operator: Token::Minus,
+                right: Box::new(Expression::IntLiteral(5)),
+            }),
+            Statement::ReturnStatement(Expression::IntLiteral(10)),
+            Statement::ReturnStatement(Expression::IntLiteral(993322)),
         ];
 
         for test in &tests {
@@ -244,6 +297,70 @@ mod tests {
             Statement::ExpressionStatement(Expression::PrefixExpression {
                 operator: Token::Minus,
                 right: Box::new(Expression::IntLiteral(15)),
+            }),
+        ];
+
+        for test in &tests {
+            match statements.next() {
+                Some(tok) => assert_eq!(*test, *tok),
+                None => panic!("unexpected parser error: returned None"),
+            };
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_infix_expr() -> Result<(), String> {
+        let input = "5+5; 5-5;
+        5*5; 5 / 5;
+        5 > 5; 5 < 5;
+        5 == 5; 5 != 5";
+        let lexer = Lexer::new(input);
+        let mut parser = Parser::new(lexer);
+
+        let program = parser.parse_program()?;
+        let mut statements = program.iter();
+
+        let tests = [
+            Statement::ExpressionStatement(Expression::InfixExpression {
+                operator: Token::Plus,
+                left: Box::new(Expression::IntLiteral(5)),
+                right: Box::new(Expression::IntLiteral(5)),
+            }),
+            Statement::ExpressionStatement(Expression::InfixExpression {
+                operator: Token::Minus,
+                left: Box::new(Expression::IntLiteral(5)),
+                right: Box::new(Expression::IntLiteral(5)),
+            }),
+            Statement::ExpressionStatement(Expression::InfixExpression {
+                operator: Token::Asterisk,
+                left: Box::new(Expression::IntLiteral(5)),
+                right: Box::new(Expression::IntLiteral(5)),
+            }),
+            Statement::ExpressionStatement(Expression::InfixExpression {
+                operator: Token::Slash,
+                left: Box::new(Expression::IntLiteral(5)),
+                right: Box::new(Expression::IntLiteral(5)),
+            }),
+            Statement::ExpressionStatement(Expression::InfixExpression {
+                operator: Token::GreaterThan,
+                left: Box::new(Expression::IntLiteral(5)),
+                right: Box::new(Expression::IntLiteral(5)),
+            }),
+            Statement::ExpressionStatement(Expression::InfixExpression {
+                operator: Token::LessThan,
+                left: Box::new(Expression::IntLiteral(5)),
+                right: Box::new(Expression::IntLiteral(5)),
+            }),
+            Statement::ExpressionStatement(Expression::InfixExpression {
+                operator: Token::Equal,
+                left: Box::new(Expression::IntLiteral(5)),
+                right: Box::new(Expression::IntLiteral(5)),
+            }),
+            Statement::ExpressionStatement(Expression::InfixExpression {
+                operator: Token::NotEqual,
+                left: Box::new(Expression::IntLiteral(5)),
+                right: Box::new(Expression::IntLiteral(5)),
             }),
         ];
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,17 +77,17 @@ impl<'a> Parser<'a> {
     fn parse_expression_statement(&mut self) -> Result<Statement, String> {
         let expr = self.parse_expression(Precedence::Lowest)?;
 
-        match self.lexer.peek() {
-            Some(Token::Semicolon) => self.next_token(),
-            _ => (),
-        };
+        if let Some(Token::Semicolon) = self.lexer.peek() {
+            self.next_token();
+        }
         Ok(Statement::ExpressionStatement(expr))
     }
 
     fn parse_expression(&mut self, _precedence: Precedence) -> Result<Expression, String> {
         match self.cursor {
             Token::Ident(_) => Ok(Expression::Ident(self.cursor.clone())),
-            _ => Err(format!("unexpected token {:?} in expression", self.cursor))
+            Token::IntLiteral(i) => Ok(Expression::IntLiteral(i)),
+            _ => Err(format!("unexpected token {:?} in expression", self.cursor)),
         }
     }
 
@@ -180,8 +180,32 @@ mod tests {
         let mut statements = program.iter();
 
         // TODO: Update test cases with proper expressions
+        let tests = [Statement::ExpressionStatement(Expression::Ident(
+            Token::Ident("foobar".to_string()),
+        ))];
+
+        for test in &tests {
+            match statements.next() {
+                Some(tok) => assert_eq!(*test, *tok),
+                None => panic!("unexpected parser error: returned None"),
+            };
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_integer_expr() -> Result<(), String> {
+        let input = "5; 1024";
+        let lexer = Lexer::new(input);
+        let mut parser = Parser::new(lexer);
+
+        let program = parser.parse_program()?;
+        let mut statements = program.iter();
+
+        // TODO: Update test cases with proper expressions
         let tests = [
-            Statement::ExpressionStatement(Expression::Ident(Token::Ident("foobar".to_string()))),
+            Statement::ExpressionStatement(Expression::IntLiteral(5)),
+            Statement::ExpressionStatement(Expression::IntLiteral(1024)),
         ];
 
         for test in &tests {
@@ -193,4 +217,3 @@ mod tests {
         Ok(())
     }
 }
-


### PR DESCRIPTION
- Implemented AST construction for `LetStatement`, `ReturnStatement`, and `ExpressionStatement`
- Expressions now left associative with BODMAS like precedence (without parentheses)
- Test cases included